### PR TITLE
Fixes optimize snippet being included when not enabled

### DIFF
--- a/src/lib/optimize.js
+++ b/src/lib/optimize.js
@@ -10,7 +10,8 @@ const ACTIVATION_METHODS = [
 class Optimize {
 
   constructor(settings = {}, tagmanager_id) {
-    const { timeout = 500, activateOn = false } = settings;
+    const { timeout = 500, activateOn = false, id = null } = settings;
+    this.optimize_id = id;
     this.tagmanager_id = tagmanager_id;
     this.timeout = timeout;
     this.activateOn = activateOn;
@@ -18,7 +19,7 @@ class Optimize {
 
   asyncHide() {
 
-    if ( !this.tagmanager_id ) return null;
+    if ( !this.tagmanager_id || !this.optimize_id ) return null;
 
     return (
       <React.Fragment key={`${COMPONENT_KEY}-asynchide`}>


### PR DESCRIPTION
If you remove your configuration for optimize you'd expect to not have the anti-flicker snippet included, but it seem, this is still included.
This adds another check for the `optimize.id`.

This change may break existing users, but this really should be explicit instead of implicit.