### PR TITLE
Filter null elements when updating head components

### DIFF
--- a/src/gatsby-ssr.js
+++ b/src/gatsby-ssr.js
@@ -10,13 +10,14 @@ function plugin({ setHeadComponents, setPreBodyComponents, setPostBodyComponents
   const analytics = new Analytics(pluginOptions.analytics, pluginOptions.optimize && pluginOptions.optimize.id);
   const optimize = new Optimize(pluginOptions.optimize, pluginOptions.tagmanager && pluginOptions.tagmanager.id);
 
-  setHeadComponents([
+  const newHeadElements = [
     tagmanager.dataLayer(),
     analytics.setup(),
     optimize.asyncHide(),
     analytics.script(),
     tagmanager.script(),
-  ]);
+  ].filter(el -> el !== null);
+  setHeadComponents(newHeadElements);
 
   setPreBodyComponents([
     tagmanager.noscript(),

--- a/src/gatsby-ssr.js
+++ b/src/gatsby-ssr.js
@@ -16,7 +16,7 @@ function plugin({ setHeadComponents, setPreBodyComponents, setPostBodyComponents
     optimize.asyncHide(),
     analytics.script(),
     tagmanager.script(),
-  ].filter(el -> el !== null);
+  ].filter(el => el !== null);
   setHeadComponents(newHeadElements);
 
   setPreBodyComponents([


### PR DESCRIPTION
Some plugins iterate over the head elements, and in the case where your analytics id is empty, you return null.

While this is fine for react, this is still exposed to other plugins.
While other plugins should likely handled the null item, it would also be good to filter them here beforehand (as a good citizen).

An example where this issue came up
https://github.com/DalkMania/gatsby-plugin-osano/pull/3
Osano wants to loop through other scripts to ensure its placed first.